### PR TITLE
fix(prost): honor file_descriptor_set argument

### DIFF
--- a/protoc-gen-prost/src/lib.rs
+++ b/protoc-gen-prost/src/lib.rs
@@ -25,9 +25,12 @@ pub fn execute(raw_request: &[u8]) -> generator::Result {
         raw_request,
         params.prost.default_package_filename(),
     )?;
+    let file_descriptor_set_generator = params
+        .file_descriptor_set
+        .then(|| FileDescriptorSetGenerator);
 
     let files = CoreProstGenerator::new(params.prost.to_prost_config())
-        .chain(FileDescriptorSetGenerator)
+        .chain(file_descriptor_set_generator)
         .generate(&module_request_set)?;
 
     Ok(files)


### PR DESCRIPTION
The (documented) `file_descriptor_set(=<boolean>)` is not honored as the descriptor set is generated regardless of this argument. This PR fixes that.