### PR TITLE
fix: properly escape all values in key=value parameters

### DIFF
--- a/protoc-gen-prost-crate/src/lib.rs
+++ b/protoc-gen-prost-crate/src/lib.rs
@@ -73,7 +73,7 @@ struct Parameters {
 
 static PARAMETER: Lazy<regex::Regex> = Lazy::new(|| {
     regex::Regex::new(
-        r"(?:(?P<param>[^,=]+)(?:=(?P<key>[^,=]+)(?:=(?P<value>(?:[^,=\\]|\\,|\\)+))?)?)",
+        r"(?:(?P<param>[^,=]+)(?:=(?P<key>[^,=]+)(?:=(?P<value>(?:[^,=\\]|\\,|\\=|\\\\)+))?)?)",
     )
     .unwrap()
 });
@@ -90,7 +90,12 @@ impl str::FromStr for Parameters {
                 .trim();
 
             let key = capture.get(2).map(|m| m.as_str());
-            let value = capture.get(3).map(|m| m.as_str());
+            let value = capture.get(3).map(|m| {
+                m.as_str()
+                    .replace(r"\,", r",")
+                    .replace(r"\=", r"=")
+                    .replace(r"\\", r"\")
+            });
 
             match (param, key, value) {
                 ("default_package_filename", value, None) => {


### PR DESCRIPTION
The previous regex and handling only allowed for `,` to be escaped, leaving out the `=` character as un-escapeable. This is problematic when the value needs one, such as adding `#[cfg(feature = "...", ...)]` directives to types using the `type_attribute` from the prost generator.