### PR TITLE
feat(prost-crate): add package_separator option

### DIFF
--- a/protoc-gen-prost-crate/src/lib.rs
+++ b/protoc-gen-prost-crate/src/lib.rs
@@ -30,7 +30,7 @@ pub fn execute(raw_request: &[u8]) -> Result {
     } else {
         params.include_file.as_deref().unwrap_or("mod.rs")
     };
-    let package_separator = params.package_separator.as_deref().unwrap_or("_");
+    let package_separator = params.package_separator.as_deref().unwrap_or("-");
 
     let limiter = Rc::new(params.only_include);
 
@@ -71,7 +71,7 @@ struct Parameters {
     only_include: PackageLimiter,
 
     /// Replace the `.` separator in package names to this character for cargo feature flags.
-    /// Defaults to `_` for compatibility with crates.io (see
+    /// Defaults to `-` for compatibility with crates.io (see
     /// [the documentation](https://doc.rust-lang.org/cargo/reference/features.html#the-features-section)
     /// for more details).
     ///


### PR DESCRIPTION
This option allows to customize the replacement character for `.` in feature names. Those are made using proto package names, but those contains `.`, which is not a valid character for a feature flag on crates.io.

Currently, the dot is replaced by an `_` character, which can lead to conflicts with similarily named packages (such as `foo.bar` and `foo_bar`).
A solid choice to avoid both issues is to use `-`, which is allowed by crates.io but illegal in a proto package name.

With this option, an user can choose:
- to keep the current (default) behavior or `.` -> `_`
- to replace with a dash for both conflict-free and crates.io compatibility
- to replace with a dot (i.e. no-op) for better developer ergonomics if publishing to crates.io is not required

I chose to keep the `_` default as not to make any breaking change. However, if you are ok with such a small one, I'd be happy to make `-` the default (though weird to look at, `_` and `-` don't mix very well).

Thanks!