### PR TITLE
[protoc-gen-tonic] Add option to disable transport generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "autocfg"
@@ -22,9 +22,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cfg-if"
@@ -34,15 +34,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -61,9 +61,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "indexmap"
@@ -101,9 +101,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "log"
@@ -122,9 +122,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "pbjson-build"
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
+checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
+checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
  "bytes",
  "heck",
@@ -214,11 +214,10 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
+checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
- "bytes",
  "prost",
 ]
 
@@ -282,9 +281,9 @@ version = "1.0.0+3.20.1"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -300,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "regex-syntax",
 ]
@@ -324,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -362,15 +361,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "which"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,8 @@ dependencies = [
 [[package]]
 name = "tonic-build"
 version = "0.8.4"
-source = "git+https://github.com/hyperium/tonic?branch=master#bf22a740c3b6391ab08b4577550f6218edc77086"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +199,8 @@ dependencies = [
  "prettyplease",
  "prost",
  "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
@@ -281,6 +289,26 @@ name = "protoc-wkt"
 version = "1.0.0+3.20.1"
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "10.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0194e6e1966c23cc5fd988714f85b18d548d773e81965413555d96569931833d"
+dependencies = [
+ "pulldown-cmark",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,10 +389,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "which"
@@ -398,3 +441,8 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[patch.unused]]
+name = "tonic-build"
+version = "0.8.4"
+source = "git+https://github.com/hyperium/tonic?branch=master#bf22a740c3b6391ab08b4577550f6218edc77086"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cfg-if"
@@ -67,9 +67,9 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -101,9 +101,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "log"
@@ -113,12 +113,6 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "multimap"
@@ -175,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -199,8 +193,6 @@ dependencies = [
  "prettyplease",
  "prost",
  "prost-types",
- "pulldown-cmark",
- "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
@@ -209,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -289,26 +281,6 @@ name = "protoc-wkt"
 version = "1.0.0+3.20.1"
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
-dependencies = [
- "bitflags",
- "memchr",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-to-cmark"
-version = "10.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0194e6e1966c23cc5fd988714f85b18d548d773e81965413555d96569931833d"
-dependencies = [
- "pulldown-cmark",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -377,9 +349,8 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c6fd7c2581e36d63388a9e04c350c21beb7a8b059580b2e93993c526899ddc"
+version = "0.8.4"
+source = "git+https://github.com/hyperium/tonic?branch=master#bf22a740c3b6391ab08b4577550f6218edc77086"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -389,25 +360,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "which"
@@ -441,8 +397,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[patch.unused]]
-name = "tonic-build"
-version = "0.8.4"
-source = "git+https://github.com/hyperium/tonic?branch=master#bf22a740c3b6391ab08b4577550f6218edc77086"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ members = [
 codegen-units = 1
 lto = "fat"
 debug = true
+
+[patch.crates-io]
+tonic-build = { git = "https://github.com/hyperium/tonic", branch = "master"  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,3 @@ members = [
 codegen-units = 1
 lto = "fat"
 debug = true
-
-[patch.crates-io]
-tonic-build = { git = "https://github.com/hyperium/tonic", branch = "master"  }

--- a/protoc-gen-tonic/Cargo.toml
+++ b/protoc-gen-tonic/Cargo.toml
@@ -24,7 +24,6 @@ prost = { version = "0.11.0", default-features = false, features = ["std"] }
 protoc-gen-prost = { version = "0.2.0", path = "../protoc-gen-prost" }
 regex = { version = "1.5.5", default-features = false }
 syn = { version = "1.0.89", features = ["parsing", "full"] }
-# tonic-build = { version = "0.8.4", default-features = false, features = ["cleanup-markdown", "prost"] }
 tonic-build = "0.8.4"
 
 [profile.release]

--- a/protoc-gen-tonic/Cargo.toml
+++ b/protoc-gen-tonic/Cargo.toml
@@ -24,11 +24,8 @@ prost = { version = "0.11.0", default-features = false, features = ["std"] }
 protoc-gen-prost = { version = "0.2.0", path = "../protoc-gen-prost" }
 regex = { version = "1.5.5", default-features = false }
 syn = { version = "1.0.89", features = ["parsing", "full"] }
-tonic-build = { version = "0.8", default-features = false, features = ["cleanup-markdown", "prost"] }
-
-[features]
-default = ["transport"]
-transport = ["tonic-build/transport"]
+# tonic-build = { version = "0.8.4", default-features = false, features = ["cleanup-markdown", "prost"] }
+tonic-build = "0.8.4"
 
 [profile.release]
 codegen-units = 1

--- a/protoc-gen-tonic/Cargo.toml
+++ b/protoc-gen-tonic/Cargo.toml
@@ -24,7 +24,11 @@ prost = { version = "0.11.0", default-features = false, features = ["std"] }
 protoc-gen-prost = { version = "0.2.0", path = "../protoc-gen-prost" }
 regex = { version = "1.5.5", default-features = false }
 syn = { version = "1.0.89", features = ["parsing", "full"] }
-tonic-build = { version = "0.8", features = [] }
+tonic-build = { version = "0.8", default-features = false, features = ["cleanup-markdown", "prost"] }
+
+[features]
+default = ["transport"]
+transport = ["tonic-build/transport"]
 
 [profile.release]
 codegen-units = 1

--- a/protoc-gen-tonic/Cargo.toml
+++ b/protoc-gen-tonic/Cargo.toml
@@ -24,7 +24,7 @@ prost = { version = "0.11.0", default-features = false, features = ["std"] }
 protoc-gen-prost = { version = "0.2.0", path = "../protoc-gen-prost" }
 regex = { version = "1.5.5", default-features = false }
 syn = { version = "1.0.89", features = ["parsing", "full"] }
-tonic-build = "0.8.4"
+tonic-build = { version = "0.8.4", features = [] }
 
 [profile.release]
 codegen-units = 1

--- a/protoc-gen-tonic/README.md
+++ b/protoc-gen-tonic/README.md
@@ -3,8 +3,8 @@
 A `protoc` plugin that generates _[Tonic]_ gRPC server and client code using
 the _[Prost!]_ code generation engine.
 
-[Tonic]: https://github.com/hyperium/tonic
-[Prost!]: https://github.com/tokio-rs/prost
+[tonic]: https://github.com/hyperium/tonic
+[prost!]: https://github.com/tokio-rs/prost
 
 When used in projects that use only Rust code, the preferred mechanism for
 generating gRPC services with _Tonic_ is to use [`tonic-build`] from
@@ -33,34 +33,35 @@ that are expected to have been completely handled in an earlier
 `protoc-gen-prost` step. For information on the effects of these settings,
 see the related documentation from `tonic-build`:
 
-* `default_package_filename=<value>`: [default_package_filename](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.default_package_filename)
-* `extern_path=<proto_path>=<rust_path>`:  [extern_path](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.extern_path)
-* `compile_well_known_types(=<boolean>)`: [compile_well_known_types](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.compile_well_known_types)
-* `disable_package_emission(=<boolean>)`: [disable_package_emission](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.disable_package_emission)
-* `server_attribute=<proto_path>=<attribute>`: [server_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.server_attribute)
-* `server_mod_attribute=<proto_path>=<attribute>`: [server_mod_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.server_mod_attribute)
-* `client_attribute=<proto_path>=<attribute>`: [client_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.client_attribute)
-* `client_mod_attribute=<proto_path>=<attribute>`: [client_mod_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.client_mod_attribute)
+- `default_package_filename=<value>`: [default_package_filename](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.default_package_filename)
+- `extern_path=<proto_path>=<rust_path>`: [extern_path](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.extern_path)
+- `compile_well_known_types(=<boolean>)`: [compile_well_known_types](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.compile_well_known_types)
+- `disable_package_emission(=<boolean>)`: [disable_package_emission](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.disable_package_emission)
+- `server_attribute=<proto_path>=<attribute>`: [server_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.server_attribute)
+- `server_mod_attribute=<proto_path>=<attribute>`: [server_mod_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.server_mod_attribute)
+- `client_attribute=<proto_path>=<attribute>`: [client_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.client_attribute)
+- `client_mod_attribute=<proto_path>=<attribute>`: [client_mod_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.client_mod_attribute)
 
 In addition, the following options can also be specified:
 
-* `no_server(=<boolean>)`: Disables generation of the server modules
-* `no_client(=<boolean>)`: Disables generation of the client modules
-* `no_include(=<boolean>)`:  Skips adding an include into the file generated
+- `no_server(=<boolean>)`: Disables generation of the server modules
+- `no_client(=<boolean>)`: Disables generation of the client modules
+- `no_transport(=<boolean>)`: Disables generation of connect method using `tonic::transport::Channel`
+- `no_include(=<boolean>)`: Skips adding an include into the file generated
   by `protoc-gen-prost`. This behavior may be desired if this plugin is run
   in a separate `protoc` invocation and you encounter a `Tried to insert into
-  file that doesn't exist` error.
+file that doesn't exist` error.
 
 A note on parameter values:
 
-* `<attribute>`: All `,`s appearing in the value must be `\` escaped
+- `<attribute>`: All `,`s appearing in the value must be `\` escaped
   (i.e. `\,`) This is due to the fact that internally, `protoc` joins all
   passed parameters with a `,` before sending it as a single string to the
   underlying plugin.
-* `<proto_path>`: Protobuf paths beginning with `.` will be matched from the
+- `<proto_path>`: Protobuf paths beginning with `.` will be matched from the
   global root (prefix matches). All other paths will be matched as suffix
   matches.
-* `(=<boolean>)`: Boolean values may be specified after a parameter, but if
+- `(=<boolean>)`: Boolean values may be specified after a parameter, but if
   not, the value is assumed to be `true` by virtue of having listed the
   parameter.
 

--- a/protoc-gen-tonic/README.md
+++ b/protoc-gen-tonic/README.md
@@ -3,8 +3,8 @@
 A `protoc` plugin that generates _[Tonic]_ gRPC server and client code using
 the _[Prost!]_ code generation engine.
 
-[tonic]: https://github.com/hyperium/tonic
-[prost!]: https://github.com/tokio-rs/prost
+[Tonic]: https://github.com/hyperium/tonic
+[Prost!]: https://github.com/tokio-rs/prost
 
 When used in projects that use only Rust code, the preferred mechanism for
 generating gRPC services with _Tonic_ is to use [`tonic-build`] from
@@ -33,35 +33,35 @@ that are expected to have been completely handled in an earlier
 `protoc-gen-prost` step. For information on the effects of these settings,
 see the related documentation from `tonic-build`:
 
-- `default_package_filename=<value>`: [default_package_filename](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.default_package_filename)
-- `extern_path=<proto_path>=<rust_path>`: [extern_path](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.extern_path)
-- `compile_well_known_types(=<boolean>)`: [compile_well_known_types](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.compile_well_known_types)
-- `disable_package_emission(=<boolean>)`: [disable_package_emission](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.disable_package_emission)
-- `server_attribute=<proto_path>=<attribute>`: [server_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.server_attribute)
-- `server_mod_attribute=<proto_path>=<attribute>`: [server_mod_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.server_mod_attribute)
-- `client_attribute=<proto_path>=<attribute>`: [client_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.client_attribute)
-- `client_mod_attribute=<proto_path>=<attribute>`: [client_mod_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.client_mod_attribute)
+* `default_package_filename=<value>`: [default_package_filename](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.default_package_filename)
+* `extern_path=<proto_path>=<rust_path>`:  [extern_path](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.extern_path)
+* `compile_well_known_types(=<boolean>)`: [compile_well_known_types](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.compile_well_known_types)
+* `disable_package_emission(=<boolean>)`: [disable_package_emission](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.disable_package_emission)
+* `server_attribute=<proto_path>=<attribute>`: [server_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.server_attribute)
+* `server_mod_attribute=<proto_path>=<attribute>`: [server_mod_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.server_mod_attribute)
+* `client_attribute=<proto_path>=<attribute>`: [client_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.client_attribute)
+* `client_mod_attribute=<proto_path>=<attribute>`: [client_mod_attribute](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.client_mod_attribute)
 
 In addition, the following options can also be specified:
 
-- `no_server(=<boolean>)`: Disables generation of the server modules
-- `no_client(=<boolean>)`: Disables generation of the client modules
-- `no_transport(=<boolean>)`: Disables generation of connect method using `tonic::transport::Channel`
-- `no_include(=<boolean>)`: Skips adding an include into the file generated
+* `no_server(=<boolean>)`: Disables generation of the server modules
+* `no_client(=<boolean>)`: Disables generation of the client modules
+* `no_transport(=<boolean>)`: Disables generation of connect method using `tonic::transport::Channel`
+* `no_include(=<boolean>)`:  Skips adding an include into the file generated
   by `protoc-gen-prost`. This behavior may be desired if this plugin is run
   in a separate `protoc` invocation and you encounter a `Tried to insert into
-file that doesn't exist` error.
+  file that doesn't exist` error.
 
 A note on parameter values:
 
-- `<attribute>`: All `,`s appearing in the value must be `\` escaped
+* `<attribute>`: All `,`s appearing in the value must be `\` escaped
   (i.e. `\,`) This is due to the fact that internally, `protoc` joins all
   passed parameters with a `,` before sending it as a single string to the
   underlying plugin.
-- `<proto_path>`: Protobuf paths beginning with `.` will be matched from the
+* `<proto_path>`: Protobuf paths beginning with `.` will be matched from the
   global root (prefix matches). All other paths will be matched as suffix
   matches.
-- `(=<boolean>)`: Boolean values may be specified after a parameter, but if
+* `(=<boolean>)`: Boolean values may be specified after a parameter, but if
   not, the value is assumed to be `true` by virtue of having listed the
   parameter.
 

--- a/protoc-gen-tonic/src/generator.rs
+++ b/protoc-gen-tonic/src/generator.rs
@@ -11,6 +11,7 @@ pub(crate) struct TonicGenerator {
     pub(crate) resolver: Resolver,
     pub(crate) generate_server: bool,
     pub(crate) generate_client: bool,
+    pub(crate) generate_transport: bool,
     pub(crate) server_attributes: Attributes,
     pub(crate) client_attributes: Attributes,
     pub(crate) emit_package: bool,
@@ -46,22 +47,20 @@ impl TonicGenerator {
                     })
                     .flat_map(|service| {
                         let client = self.generate_client.then(|| {
-                            tonic_build::client::generate(
-                                &service,
-                                self.emit_package,
-                                PROTO_PATH,
-                                self.resolver.compile_well_known_types(),
-                                &self.client_attributes,
-                            )
+                            tonic_build::CodeGenBuilder::new()
+                                .emit_package(self.emit_package)
+                                .build_transport(self.generate_transport)
+                                .compile_well_known_types(self.resolver.compile_well_known_types())
+                                .attributes(self.client_attributes.clone())
+                                .generate_client(&service, PROTO_PATH)
                         });
                         let server = self.generate_server.then(|| {
-                            tonic_build::server::generate(
-                                &service,
-                                self.emit_package,
-                                PROTO_PATH,
-                                self.resolver.compile_well_known_types(),
-                                &self.server_attributes,
-                            )
+                            tonic_build::CodeGenBuilder::new()
+                                .emit_package(self.emit_package)
+                                .build_transport(self.generate_transport)
+                                .compile_well_known_types(self.resolver.compile_well_known_types())
+                                .attributes(self.server_attributes.clone())
+                                .generate_server(&service, PROTO_PATH)
                         });
 
                         client.into_iter().chain(server)

--- a/protoc-gen-tonic/src/lib.rs
+++ b/protoc-gen-tonic/src/lib.rs
@@ -30,6 +30,7 @@ pub fn execute(raw_request: &[u8]) -> protoc_gen_prost::Result {
         resolver,
         generate_server: !params.no_server,
         generate_client: !params.no_client,
+        generate_transport: !params.no_transport,
         server_attributes: params.server_attributes,
         client_attributes: params.client_attributes,
         emit_package: !params.disable_package_emission,
@@ -54,6 +55,7 @@ struct Parameters {
     disable_package_emission: bool,
     no_server: bool,
     no_client: bool,
+    no_transport: bool,
     no_include: bool,
 }
 
@@ -113,6 +115,17 @@ impl str::FromStr for Parameters {
                 } => ret_val.no_client = true,
                 Param::Value {
                     param: "no_client",
+                    value: "false",
+                } => (),
+                Param::Parameter {
+                    param: "no_transport",
+                }
+                | Param::Value {
+                    param: "no_transport",
+                    value: "true",
+                } => ret_val.no_transport = true,
+                Param::Value {
+                    param: "no_transport",
                     value: "false",
                 } => (),
                 Param::Parameter {

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,5 +1,103 @@
 
 # cargo-vet audits file
 
-[audits]
+[[audits.anyhow]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.0.66 -> 1.0.69"
+
+[[audits.bytes]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.2.1 -> 1.4.0"
+
+[[audits.either]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.8.0 -> 1.8.1"
+
+[[audits.fastrand]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.8.0 -> 1.9.0"
+
+[[audits.heck]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
+
+[[audits.indexmap]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.9.1 -> 1.9.2"
+
+[[audits.once_cell]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.16.0 -> 1.17.1"
+
+[[audits.petgraph]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "0.6.2 -> 0.6.3"
+
+[[audits.prettyplease]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "0.1.21 -> 0.1.23"
+
+[[audits.proc-macro2]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.0.47 -> 1.0.51"
+
+[[audits.prost]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "0.11.2 -> 0.11.8"
+
+[[audits.prost-build]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "0.11.1 -> 0.11.8"
+
+[[audits.prost-derive]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "0.11.2 -> 0.11.8"
+
+[[audits.prost-types]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "0.11.2 -> 0.11.8"
+
+[[audits.quote]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.0.21 -> 1.0.23"
+
+[[audits.regex]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.7.0 -> 1.7.1"
+
+[[audits.syn]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.0.103 -> 1.0.109"
+
+[[audits.tonic-build]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "0.8.2 -> 0.8.4"
+
+[[audits.unicode-ident]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "1.0.5 -> 1.0.6"
+
+[[audits.which]]
+who = "Marcus Griep <marcus@griep.us>"
+criteria = "safe-to-deploy"
+delta = "4.3.0 -> 4.4.0"
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -16,6 +16,9 @@ audit-as-crates-io = false
 [policy.protoc-gen-tonic]
 audit-as-crates-io = false
 
+[policy.protoc-wkt]
+audit-as-crates-io = false
+
 [[exemptions.anyhow]]
 version = "1.0.66"
 criteria = "safe-to-deploy"
@@ -73,7 +76,7 @@ version = "1.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
-version = "0.2.137"
+version = "0.2.139"
 criteria = "safe-to-deploy"
 
 [[exemptions.log]]


### PR DESCRIPTION
## Background
- https://github.com/neoeinstein/protoc-gen-prost/issues/42
- Currently, transport is always generated for tonic grpc services which is a problem for consumers who want to compile for wasm. The latest version `tonic-build="0.8.4"` allows us to disable this 

## Changes
- Update tonic-build to v0.8.4
- Add `tonic_opt` option `no_transport`
- Migrate from deprecated `generate` APIs to `tonic_build::CodeGenBuilder`
- Update `prost-build` ti 0.11.4 in all crates
  - This was required for cargo crate resolution to succeed 
- Update README

## Tests
-[x] `cargo test` - everything is passing
-[x] Used this package to regenerate my own protos
  - [x] Confirmed that the `connect()` function wasnt generated
  - Just an FYI that there is now `#[allow(clippy::derive_partial_eq_without_eq)]` macros in the generated code 

