### PR TITLE
Update buf.build plugin references

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ remote plugin.
 ```yaml
 version: v1
 plugins:
-  - remote: buf.build/prost/plugins/prost:v0.2.1-1
+  - plugin: buf.build/community/neoeinstein-prost:v0.2.2
     out: gen/src
     opt:
       - bytes=.
       - compile_well_known_types
       - extern_path=.google.protobuf=::pbjson_types
       - file_descriptor_set
-  - remote: buf.build/prost/plugins/serde:v0.2.1-1
+  - plugin: buf.build/community/neoeinstein-prost-serde:v0.2.3
     out: gen/src
-  - remote: buf.build/prost/plugins/tonic:v0.2.1-1
+  - plugin: buf.build/community/neoeinstein-tonic:v0.2.2
     out: gen/src
     opt:
       - compile_well_known_types

--- a/protoc-gen-prost-serde/README.md
+++ b/protoc-gen-prost-serde/README.md
@@ -112,12 +112,12 @@ a plugin which you can execute remotely, without needing to explicitly install
 this tool. See the [plugin listing][1] to identify the latest published version
 for use. The plugin is referenced as follows:
 
-[1]: https://buf.build/prost/plugins/serde
+[1]: https://buf.build/community/neoeinstein-prost-serde
 
 ```yaml
 version: v1
 plugins:
-  - remote: buf.build/prost/plugins/serde:v0.2.1-1
+  - plugin: buf.build/community/neoeinstein-prost-serde:v0.2.3
     out: gen
 ```
 

--- a/protoc-gen-prost/README.md
+++ b/protoc-gen-prost/README.md
@@ -86,12 +86,12 @@ a plugin which you can execute remotely, without needing to explicitly install
 this tool. See the [plugin listing][1] to identify the latest published version
 for use. The plugin is referenced as follows:
 
-[1]: https://buf.build/prost/plugins/prost
+[1]: https://buf.build/community/neoeinstein-prost
 
 ```yaml
 version: v1
 plugins:
-  - remote: buf.build/prost/plugins/prost:v0.2.1-1
+  - plugin: buf.build/community/neoeinstein-prost:v0.2.2
     out: gen
 ```
 

--- a/protoc-gen-tonic/README.md
+++ b/protoc-gen-tonic/README.md
@@ -115,12 +115,12 @@ a plugin which you can execute remotely, without needing to explicitly install
 this tool. See the [plugin listing][1] to identify the latest published version
 for use. The plugin is referenced as follows:
 
-[1]: https://buf.build/prost/plugins/tonic
+[1]: https://buf.build/community/neoeinstein-tonic
 
 ```yaml
 version: v1
 plugins:
-  - remote: buf.build/prost/plugins/tonic:v0.2.1-1
+  - plugin: buf.build/community/neoeinstein-tonic:v0.2.2
     out: gen
 ```
 


### PR DESCRIPTION
This PR updates the buf.build plugin references.

A while back [we announced](https://buf.build/blog/remote-packages-remote-plugins-approaching-v1) that user-uploaded plugins will be removed from the BSR in favor of custom plugins and Buf-managed plugins.

Given these were popular plugins, we included them as community plugins:

- https://github.com/bufbuild/plugins/pull/288
- https://github.com/bufbuild/plugins/pull/401

This does mean the `buf.gen.yaml` will slightly change, and likewise will the references themselves. There's a bit more detail in [Migrating from alpha](https://buf.build/docs/bsr/remote-packages/migrating-from-alpha/) documentation.

Note, there is one plugin that is not currently available as a community plugin: https://buf.build/prost/plugins/crate