### PR TITLE
Add executable targets to all packages

### DIFF
--- a/protoc-gen-prost-crate/Cargo.toml
+++ b/protoc-gen-prost-crate/Cargo.toml
@@ -26,3 +26,8 @@ regex = { version = "1.5.5", default-features = false }
 codegen-units = 1
 lto = "fat"
 debug = true
+
+[[bin]]
+
+name = "protoc-gen-prost-crate"
+path = "src/main.rs"

--- a/protoc-gen-prost-serde/Cargo.toml
+++ b/protoc-gen-prost-serde/Cargo.toml
@@ -26,3 +26,8 @@ regex = { version = "1.5.5", default-features = false }
 codegen-units = 1
 lto = "fat"
 debug = true
+
+[[bin]]
+
+name = "protoc-gen-prost-serde"
+path = "src/main.rs"

--- a/protoc-gen-prost/Cargo.toml
+++ b/protoc-gen-prost/Cargo.toml
@@ -27,3 +27,8 @@ regex = { version = "1.5.5", default-features = false }
 codegen-units = 1
 lto = "fat"
 debug = true
+
+[[bin]]
+
+name = "protoc-gen-prost"
+path = "src/main.rs"

--- a/protoc-gen-tonic/Cargo.toml
+++ b/protoc-gen-tonic/Cargo.toml
@@ -30,3 +30,8 @@ tonic-build = { version = "0.9.2", features = [] }
 codegen-units = 1
 lto = "fat"
 debug = true
+
+[[bin]]
+
+name = "protoc-gen-tonic"
+path = "src/main.rs"


### PR DESCRIPTION
In order to use these plugins programmatically via `protoc` - we need to build `main.rs` into executables.