### PR TITLE
added btree_map support to prost-serde

### DIFF
--- a/protoc-gen-prost-serde/README.md
+++ b/protoc-gen-prost-serde/README.md
@@ -33,6 +33,7 @@ This tool supports all the same options from `pbjson-build`. For more
 information on the effects of these settings, see the related documentation
 from that crate:
 
+* `btree_map=<proto_path>`: [btree_map](https://docs.rs/pbjson-build/latest/pbjson_build/struct.Builder.html#method.btree_map)
 * `default_package_filename=<value>`: [default_package_filename](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.default_package_filename)
 * `extern_path=<proto_path>=<rust_path>`:  [extern_path](https://docs.rs/pbjson-build/latest/pbjson_build/struct.Builder.html#method.extern_path)
 * `retain_enum_prefix(=<boolean>)`:  [retain_enum_prefix](https://docs.rs/pbjson-build/latest/pbjson_build/struct.Builder.html#method.retain_enum_prefix)

--- a/protoc-gen-prost-serde/src/lib.rs
+++ b/protoc-gen-prost-serde/src/lib.rs
@@ -45,6 +45,7 @@ struct Parameters {
     emit_fields: bool,
     use_integers_for_enums: bool,
     no_include: bool,
+    btree_map: Vec<String>,
 }
 
 impl Parameters {
@@ -74,6 +75,12 @@ impl Parameters {
         if self.use_integers_for_enums {
             builder.use_integers_for_enums();
         }
+
+        if !self.btree_map.is_empty() {
+            builder.btree_map(self.btree_map.clone());
+        }
+
+        builder.btree_map(self.btree_map.clone());
 
         builder
     }
@@ -151,6 +158,10 @@ impl str::FromStr for Parameters {
                     key: prefix,
                     value: module,
                 } => ret_val.extern_path.push((prefix.to_string(), module)),
+                Param::Value {
+                    param: "btree_map",
+                    value,
+                } => ret_val.btree_map.push(value.to_string()),
                 _ => return Err(InvalidParameter::from(param)),
             }
         }


### PR DESCRIPTION
This fixes a hidden bug where users can use `btree_map=.` in `protoc-gen-prost` but it would break when uses with `protoc-gen-prost-serde`. Now users can use it in both places. I tested it with a complex workspace with `buf` and it worked as intended.

Example from generated code, see `metadata__`:

```rust
struct GeneratedVisitor;
impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
    type Value = ErrorInfo;

    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        formatter.write_str("struct google.rpc.ErrorInfo")
    }

    fn visit_map<V>(self, mut map: V) -> std::result::Result<ErrorInfo, V::Error>
    where
        V: serde::de::MapAccess<'de>,
    {
        let mut reason__ = None;
        let mut domain__ = None;
        let mut metadata__ = None;
        while let Some(k) = map.next_key()? {
            match k {
                GeneratedField::Reason => {
                    if reason__.is_some() {
                        return Err(serde::de::Error::duplicate_field("reason"));
                    }
                    reason__ = Some(map.next_value()?);
                }
                GeneratedField::Domain => {
                    if domain__.is_some() {
                        return Err(serde::de::Error::duplicate_field("domain"));
                    }
                    domain__ = Some(map.next_value()?);
                }
                GeneratedField::Metadata => {
                    if metadata__.is_some() {
                        return Err(serde::de::Error::duplicate_field("metadata"));
                    }
                    metadata__ =
                        Some(map.next_value::<std::collections::BTreeMap<_, _>>()?);
                }
            }
        }
        Ok(ErrorInfo {
            reason: reason__.unwrap_or_default(),
            domain: domain__.unwrap_or_default(),
            metadata: metadata__.unwrap_or_default(),
        })
    }
}
``` 