### PR TITLE
Update docs example for prost-crate remote BSR usage

### DIFF
--- a/protoc-gen-prost-crate/README.md
+++ b/protoc-gen-prost-crate/README.md
@@ -132,6 +132,8 @@ version: v1
 plugins:
   - plugin: buf.build/community/neoeinstein-prost-crate:v0.3.1
     out: gen
+    opt:
+      - no_features
 ```
 
 ## Cargo manifest template


### PR DESCRIPTION
Updating remote plugin example for prost-crate for consistency with [usage guide](https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost-crate#usage-with-buf). `no_features` option is necessary for usage on the BSR.