### PR TITLE
build: clippy lints show as line comments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,8 +27,9 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets --all-features --locked -- -D warnings
-
+      - uses: actions-rs-plus/clippy-check@v2
+        with:
+          args: --all-targets --all-features --locked
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -104,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v5
         with:
           name: binary-release
           path: bin


### PR DESCRIPTION
Also fixes the `build-with-buf` workflow